### PR TITLE
Fix nuspec to not get every dll in the bin folder, 1.0.0 package contain...

### DIFF
--- a/SpecFlow.Assist.Dynamic/SpecFlow.Assist.Dynamic.nuspec
+++ b/SpecFlow.Assist.Dynamic/SpecFlow.Assist.Dynamic.nuspec
@@ -17,6 +17,6 @@
   </metadata>
   <files>
     <file src="App.config.transform" target="content\App.config.transform" />
-    <file src="bin\Release\*.dll" target="lib\40" />
+    <file src="bin\Release\SpecFlow.Assist.Dynamic.dll" target="lib\40" />
   </files>
 </package>


### PR DESCRIPTION
...s SpecFlow.dll and ImpromptuInterface.dll.

This replaces the HintPath of the SpecFlow dll to the one contained in your package. This can result in unwanted behavior. 
