### PR TITLE
Remove Console.WriteLine() from showing up in SpecFlow reports

### DIFF
--- a/SpecFlow.Assist.Dynamic/DynamicTableHelpers.cs
+++ b/SpecFlow.Assist.Dynamic/DynamicTableHelpers.cs
@@ -261,8 +261,6 @@ namespace TechTalk.SpecFlow.Assist
             var cleanedHeader = RemoveReservedChars(header);
             var propName = FixCasing(cleanedHeader);
 
-            Console.WriteLine("\t- column '{0}' converted to property '{1}'", header, propName);
-        
             // Throw if no chars in string
             if (propName.Length != 0) return propName;
             


### PR DESCRIPTION
The console output here is introducing some noise in SpecFlow report outputs.